### PR TITLE
Suppresses ProGuard warning for missing FontFamily

### DIFF
--- a/library/proguard-rules.pro
+++ b/library/proguard-rules.pro
@@ -16,6 +16,8 @@
 #   public *;
 #}
 
+-dontwarn android.graphics.FontFamily
+
 -keep class android.support.annotation.Keep
 
 -keepclassmembers @android.support.annotation.Keep class * {


### PR DESCRIPTION
This was causing build failures when ProGuard was enabled.
