### PR TITLE
Support Android Nougat #5

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -50,6 +50,9 @@
             </value>
           </option>
         </AndroidXmlCodeStyleSettings>
+        <MarkdownNavigatorCodeStyleSettings>
+          <option name="RIGHT_MARGIN" value="72" />
+        </MarkdownNavigatorCodeStyleSettings>
         <Objective-C-extensions>
           <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK" />
           <option name="RELEASE_STYLE" value="IVAR" />

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-alpha3'
+        classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
 

--- a/library/src/main/java/com/meetme/support/fonts/FontManager.java
+++ b/library/src/main/java/com/meetme/support/fonts/FontManager.java
@@ -43,7 +43,7 @@ public final class FontManager {
     private static final FontManagerImpl IMPL;
 
     static {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT >= 24) {
             if (BuildConfig.DEBUG) Log.v(TAG, "Creating FontManager-24");
             IMPL = new FontManagerImpl24();
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/library/src/main/java/com/meetme/support/fonts/FontManager.java
+++ b/library/src/main/java/com/meetme/support/fonts/FontManager.java
@@ -43,8 +43,7 @@ public final class FontManager {
     private static final FontManagerImpl IMPL;
 
     static {
-        // TODO: SDK_INT == VERSION_CODES.N
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.M && Build.VERSION.PREVIEW_SDK_INT > 0) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.PREVIEW_SDK_INT > 0) {
             if (BuildConfig.DEBUG) Log.v(TAG, "Creating FontManager-24");
             // This is Android N Preview
             IMPL = new FontManagerImpl24();

--- a/library/src/main/java/com/meetme/support/fonts/FontManager.java
+++ b/library/src/main/java/com/meetme/support/fonts/FontManager.java
@@ -43,9 +43,8 @@ public final class FontManager {
     private static final FontManagerImpl IMPL;
 
     static {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.PREVIEW_SDK_INT > 0) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (BuildConfig.DEBUG) Log.v(TAG, "Creating FontManager-24");
-            // This is Android N Preview
             IMPL = new FontManagerImpl24();
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             if (BuildConfig.DEBUG) Log.v(TAG, "Creating FontManager-21");


### PR DESCRIPTION
As described in this issue:

https://github.com/MeetMe/font-compat/issues/5

the FontManager was only including Android N Preview versions. As a result a Font Manager Implementation class was not being assigned to `IMPL` when running with Android N. Therefore, the logic was altered to allow Android versions `>=` Marshmallow to use `FontManagerImpl24()`. 
